### PR TITLE
fix: quote filepath to avoid issues when there's special chars

### DIFF
--- a/vc-msg-git.el
+++ b/vc-msg-git.el
@@ -128,7 +128,7 @@ COMMON-OPTS is used to build new blame command."
          output
          info
          (common-opts (vc-msg-git-blame-arguments line-num))
-         (cmd (vc-msg-git-generate-cmd (format "%s %s -- %s"
+         (cmd (vc-msg-git-generate-cmd (format "%s %s -- \"%s\""
                                                common-opts
                                                version
                                                file))))


### PR DESCRIPTION
e.g. [] in file path

‘git --no-pager blame -C -M -w -L 67,+1 --no-merges --porcelain -- apps/volcengine/src/routes/[product$]/components/buy-form.tsx‘ failed